### PR TITLE
Add default for USER when unset (bash profile)

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,4 +1,4 @@
-if [ -n "$HOME" ] && [ -n "$USER" ]; then
+if [ -n "$HOME" ] && [ -n "$USER" ] && ! USER=$(id -u -n); then
     __savedpath="$PATH"
     export PATH=@coreutils@
 


### PR DESCRIPTION
See:
- https://github.com/NixOS/nix/pull/3007
- https://github.com/NixOS/nix/issues/971

This is still broken, e.g. when running the no-daemon install script on the circle-ci base image (cimg/base).